### PR TITLE
Expose API over local network

### DIFF
--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -5,7 +5,8 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddCors(options =>
-    options.AddPolicy("development", policy => policy.WithOrigins("http://localhost:8081")));
+    options.AddPolicy("development",
+        policy => policy.AllowAnyOrigin()));
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSignalR();

--- a/apps/api/Properties/launchSettings.json
+++ b/apps/api/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "swagger",
       "applicationUrl": "http://0.0.0.0:8080",
       "environmentVariables": {

--- a/apps/api/Properties/launchSettings.json
+++ b/apps/api/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:8080",
+      "applicationUrl": "http://0.0.0.0:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -1,5 +1,6 @@
-import { Api, WeatherForecast } from "api-client";
+import { Api } from "api-client";
 import { getReceiverRegister } from "api-signalr-client";
+import Constants from "expo-constants";
 import { ReactNode, useEffect, useState } from "react";
 import { FlatList, Text, View } from "react-native";
 import { HttpTransportType, HubConnectionBuilder } from "@microsoft/signalr";
@@ -47,7 +48,7 @@ function useWeatherForecast(): Forecast[] | null {
   useEffect(() => {
     (async () => {
       const api = new Api({
-        baseUrl: "http://localhost:8080",
+        baseUrl: getApiHostname(),
       });
       const response = await api.weatherforecast.getWeatherForecast({
         mode: "cors",
@@ -66,7 +67,7 @@ function useWeatherForecast(): Forecast[] | null {
 
   useEffect(() => {
     const connection = new HubConnectionBuilder()
-      .withUrl("http://localhost:8080/weatherforecasthub", {
+      .withUrl(`${getApiHostname()}/weatherforecasthub`, {
         skipNegotiation: true,
         transport: HttpTransportType.WebSockets,
       })
@@ -110,3 +111,18 @@ type Forecast = {
   summary?: string;
   temperature?: number;
 };
+
+function getApiHostname(): string {
+  // Typically exp://1.2.3.4:8081/
+  const { experienceUrl } = Constants;
+
+  const url = new URL(experienceUrl);
+  url.port = "8080";
+  const urlString = url.toString();
+
+  const urlWithHttp = urlString.replace(/^[^:]*/, "http");
+
+  const urlWithoutTrailingSlash = urlWithHttp.replace(/\/$/, "");
+
+  return urlWithoutTrailingSlash;
+}


### PR DESCRIPTION
## Context

Currently, we are able to test the application locally on a development machine. However, because everything is hard-coded to point to `localhost`, we cannot test it on mobile devices.

## Intention

Allow an engineer to open and test the app from their mobile device.

## Implementation

- Modify the API to accept connections from any origin while running in `Development` mode.
  - This requires that we set the host name of the API to `0.0.0.0`, which is not a valid address on Windows machines. To prevent the application from opening a browser on a non-responsive address, the API no longer opens the browser on startup. It must be opened manually.
- Modify the mobile app to calculate the address of the API based on the address of the host.
  - **Note:** Eventually, we should figure out how to do this by passing an environment variable into the mobile app. This is complicated because the environment variable needs to get the local IP address of the host machine, which is no simple task; a machine can have multiple network cards, and therefore multiple IP addresses. We need to figure out which one to use. This note has been converted into #17.

## Testing

I tested this manually for now. As we introduce more testing suites, we can add automated tests.

Here is a screenshot of the mobile app from my phone.

![Screenshot_20250413-102120.png](https://github.com/user-attachments/assets/a091a810-ef8a-41a1-9bd2-22308a00cd16)

## Ticket

This pull request resolves issue #15.
